### PR TITLE
feat: log history synthese module

### DIFF
--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -15,6 +15,7 @@ from flask import (
     g,
 )
 from werkzeug.exceptions import Forbidden, NotFound, BadRequest, Conflict
+from werkzeug.datastructures import MultiDict
 from sqlalchemy import distinct, func, desc, asc, select, case
 from sqlalchemy.orm import joinedload, lazyload, selectinload
 from geojson import FeatureCollection, Feature
@@ -40,9 +41,17 @@ from geonature.core.gn_synthese.models import (
     VSyntheseForWebApp,
     VColorAreaTaxon,
     TReport,
+    SyntheseLogEntry,
+    SyntheseQuery,
 )
 from geonature.core.gn_synthese.synthese_config import MANDATORY_COLUMNS
-
+from geonature.core.gn_synthese.utils.routes import (
+    filter_params,
+    get_sort,
+    paginate,
+    get_limit_page,
+    sort,
+)
 from geonature.core.gn_synthese.utils.query_select_sqla import SyntheseQuery
 
 from geonature.core.gn_permissions import decorators as permissions
@@ -1181,3 +1190,50 @@ def delete_report(id_report):
     else:
         DB.session.delete(reportItem)
     DB.session.commit()
+
+
+@routes.route("/log", methods=["get"])
+@permissions.check_cruved_scope("R", True, module_code="SYNTHESE")
+@json_resp
+def list_synthese_log_entries(info_role) -> dict:
+    """Get log history from synthese
+    Parameters
+    ----------
+    info_role : VUsersPermissions
+        User permissions
+    Returns
+    -------
+    dict
+        log action list
+    """
+
+    params = MultiDict(request.args)
+    limit, page = get_limit_page(params=params)
+    sort_label, sort_dir = get_sort(
+        params=params, default_sort="meta_last_action_date", default_direction="desc"
+    )
+    q1 = SyntheseLogEntry.query.with_entities(
+        SyntheseLogEntry.id_synthese,
+        SyntheseLogEntry.unique_id_sinp,
+        SyntheseLogEntry.last_action,
+        SyntheseLogEntry.meta_last_action_date,
+    )
+
+    q2 = Synthese.query.with_entities(
+        Synthese.id_synthese,
+        Synthese.unique_id_sinp,
+        Synthese.last_action,
+        func.coalesce(Synthese.meta_update_date, Synthese.meta_create_date),
+    )
+
+    q3 = q1.union(q2)
+
+    query = filter_params(query=q3, params=params)
+    query = sort(query=query, sort=sort_label, sort_dir=sort_dir)
+    data = paginate(
+        query=query,
+        limit=limit,
+        page=page,
+    )
+
+    return data

--- a/backend/geonature/core/gn_synthese/utils/routes.py
+++ b/backend/geonature/core/gn_synthese/utils/routes.py
@@ -1,0 +1,37 @@
+from typing import Tuple
+
+from flask import Response
+from flask.json import jsonify
+from geonature.utils.env import DB
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import Query
+from werkzeug.datastructures import MultiDict
+
+from geonature.core.gn_synthese.models import SyntheseQuery
+
+
+def get_limit_page(params: MultiDict) -> Tuple[int]:
+    return int(params.pop("limit", 50)), int(params.pop("page", 1))
+
+
+def get_sort(params: MultiDict, default_sort: str, default_direction) -> Tuple[str]:
+    return params.pop("sort", default_sort), params.pop("sort_dir", default_direction)
+
+
+def paginate(query: SyntheseQuery, limit: int, page: int) -> Response:
+    result = query.paginate(page=page, error_out=False, per_page=limit)
+    data = dict(items=result.items, total=result.total, limit=limit, page=page)
+
+    return data
+
+
+def filter_params(query: SyntheseQuery, params: MultiDict) -> SyntheseQuery:
+    if len(params) != 0:
+        query = query.filter_by_params(params)
+    return query
+
+
+def sort(query: SyntheseQuery, sort: str, sort_dir: str) -> SyntheseQuery:
+    if sort_dir in ["desc", "asc"]:
+        query = query.sort(label=sort, direction=sort_dir)
+    return query

--- a/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
+++ b/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
@@ -1,0 +1,71 @@
+"""add synthese log history
+
+Revision ID: 9e9218653d6c
+Revises: ca0fe5d21ea2
+Create Date: 2022-04-06 15:39:37.428357
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql.expression import null
+
+
+# revision identifiers, used by Alembic.
+revision = "9e9218653d6c"
+down_revision = "ca0fe5d21ea2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "t_log_synthese",
+        sa.Column("id_synthese", sa.Integer, primary_key=True),
+        sa.Column("unique_id_sinp", UUID(as_uuid=True), nullable=False),
+        sa.Column("last_action", sa.CHAR(1), nullable=False),
+        sa.Column("meta_last_action_date", sa.TIMESTAMP, server_default=sa.func.now()),
+        schema="gn_synthese",
+    )
+    op.execute(
+        """
+    CREATE OR REPLACE FUNCTION gn_synthese.fct_tri_log_delete_on_synthese() RETURNS TRIGGER AS
+    $BODY$
+    DECLARE
+    BEGIN
+        -- log id/uuid of deleted datas into specific log table
+        IF (TG_OP = 'DELETE') THEN
+            INSERT INTO gn_synthese.t_log_synthese
+            SELECT
+                o.id_synthese    AS id_synthese
+                , o.unique_id_sinp AS unique_id_sinp
+                , 'D'                AS last_action
+                , now()              AS meta_last_action_date
+            from old_table o
+            ON CONFLICT (id_synthese)
+            DO UPDATE SET last_action = 'D', meta_last_action_date = now();
+        END IF;
+        RETURN NULL;
+    END;
+    $BODY$ LANGUAGE plpgsql COST 100
+    ;
+    DROP TRIGGER IF EXISTS tri_log_delete_synthese ON gn_synthese.synthese;
+    CREATE TRIGGER tri_log_delete_synthese
+        AFTER DELETE
+        ON gn_synthese.synthese
+        REFERENCING OLD TABLE AS old_table
+        FOR EACH STATEMENT
+    EXECUTE FUNCTION gn_synthese.fct_tri_log_delete_on_synthese()
+    ;
+    """
+    )
+
+
+def downgrade():
+    op.drop_table("t_log_synthese", schema="gn_synthese")
+    op.execute(
+        """
+    DROP TRIGGER IF EXISTS tri_log_delete_synthese ON gn_synthese.synthese;
+    DROP FUNCTION gn_synthese.fct_tri_log_delete_on_synthese();    
+    """
+    )


### PR DESCRIPTION
Sur la base de la PR #1835 réalisé par @lpofredc 

Improving PR
[https://github.com/PnX-SI/GeoNature/pull/1835](https://github.com/PnX-SI/GeoNature/pull/1835) According to this comment :
- [x] Supprimer l’usage de GenericQuery : la manière fléché par SQLAlchemy pour cela serait d’utiliser query_class ; on peut envisager de faire des fonctions de filtrage générique de cette manière mais il faut que cela soit bien réfléchit et bien couvert par les tests. 
- [x] Supprimer la vue v_log_synthese (plus difficile à maintenir) au profit d’une requête d’union directement dans la route

Reviewed_by:andriac
[Refs_PR]: #1835